### PR TITLE
Update 69Frogs Meta

### DIFF
--- a/collections/69-frogs/meta.json
+++ b/collections/69-frogs/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "69 Frogs",
+  "inscription_icon": "d0c8ea911ad89fb56a9a66ef0fa3066c7949f2e03030b673947b44d3546521d6i0",
+  "supply": "9716",
+  "slug": "69frogs",
+  "description": "The last 10,400 Frogs based on BRC69",
+  "twitter_link": "https://twitter.com/_BitPunks_",
+  "discord_link": "https://discord.gg/bitpunks",
+  "website_link": "https://bitpunks.io"
+}


### PR DESCRIPTION
We specify the corresponding images through "high_res_img_url" in the inscriptions.json file. You can cache these images for display on the front end.