### PR TITLE
Update 69Frogs Meta

### DIFF
--- a/collections/69-frogs/meta.json
+++ b/collections/69-frogs/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "69 Frogs",
   "inscription_icon": "d0c8ea911ad89fb56a9a66ef0fa3066c7949f2e03030b673947b44d3546521d6i0",
-  "supply": "10376",
+  "supply": "10400",
   "slug": "69-frogs",
   "description": "The last 10,400 Frogs based on BRC69",
   "twitter_link": "https://twitter.com/_BitPunks_",

--- a/collections/69-frogs/meta.json
+++ b/collections/69-frogs/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "69 Frogs",
   "inscription_icon": "d0c8ea911ad89fb56a9a66ef0fa3066c7949f2e03030b673947b44d3546521d6i0",
-  "supply": "9917",
+  "supply": "10376",
   "slug": "69-frogs",
   "description": "The last 10,400 Frogs based on BRC69",
   "twitter_link": "https://twitter.com/_BitPunks_",

--- a/collections/69-frogs/meta.json
+++ b/collections/69-frogs/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "69 Frogs",
   "inscription_icon": "d0c8ea911ad89fb56a9a66ef0fa3066c7949f2e03030b673947b44d3546521d6i0",
-  "supply": "9716",
+  "supply": "9917",
   "slug": "69-frogs",
   "description": "The last 10,400 Frogs based on BRC69",
   "twitter_link": "https://twitter.com/_BitPunks_",


### PR DESCRIPTION
We specify the corresponding images through "high_res_img_url" in the inscriptions.json file. You can cache these images for display on the front end.